### PR TITLE
Fix: Add ProposalAuditTrail to FK cascade deletion

### DIFF
--- a/spo/routes/admin/shops.py
+++ b/spo/routes/admin/shops.py
@@ -10,6 +10,7 @@ from spo.models import (
     BonusProgram,
     Coupon,
     Proposal,
+    ProposalAuditTrail,
     RateComment,
     ScrapeLog,
     Shop,
@@ -366,22 +367,25 @@ def register_admin_shops(app):
             # 2. Delete ShopMetadataProposal (references both Shop and ShopMain)
             ShopMetadataProposal.query.delete()
 
-            # 3. Delete Proposal (references Shop) - THIS WAS MISSING!
+            # 3. Delete ProposalAuditTrail (references Proposal)
+            ProposalAuditTrail.query.delete()
+
+            # 4. Delete Proposal (references Shop)
             Proposal.query.delete()
 
-            # 4. Delete Coupon (references Shop)
+            # 5. Delete Coupon (references Shop)
             Coupon.query.delete()
 
-            # 5. Delete ShopProgramRate (references Shop)
+            # 6. Delete ShopProgramRate (references Shop)
             ShopProgramRate.query.delete()
 
-            # 6. Delete Shop entries (references ShopMain)
+            # 7. Delete Shop entries (references ShopMain)
             Shop.query.delete()
 
-            # 6. Delete ShopVariant (references ShopMain)
+            # 8. Delete ShopVariant (references ShopMain)
             ShopVariant.query.delete()
 
-            # 7. Delete ShopMain
+            # 9. Delete ShopMain
             ShopMain.query.delete()
 
             db.session.commit()


### PR DESCRIPTION

The `proposal_audit_trails` table has a foreign key to `proposals.id`, but audit trails were not being deleted before proposals in the cascade deletion order.

### Solution

**Add ProposalAuditTrail to FK cascade deletion**
- Added `ProposalAuditTrail.query.delete()` before `Proposal.query.delete()` in `admin_clear_shops()` endpoint
- Updated deletion order:
  1. ShopMergeProposal
  2. ShopMetadataProposal
  3. **ProposalAuditTrail** ← NEW
  4. Proposal
  5. Coupon
  6. ShopProgramRate
  7. Shop
  8. ShopVariant
  9. ShopMain

### Changes

**Modified Files:**
- `spo/routes/admin/shops.py` - Added ProposalAuditTrail import and deletion
- `tests/test_admin_clear_shops.py` - Added ProposalAuditTrail test coverage

**Test Coverage:**
- Test creates ProposalAuditTrail with FK to Proposal
- Verifies ProposalAuditTrail is deleted without FK violations
- Complete FK chain validation including audit trails

### Testing

✅ All tests pass:
```bash
docker-compose exec -T shopping-points python -m pytest [test_admin_clear_shops.py](http://_vscodecontentref_/0) -v
# 1 passed in 1.15s