### PR TITLE
Fix job logs template syntax and stale job cleanup

### DIFF
--- a/templates/admin_scheduled_job_logs.html
+++ b/templates/admin_scheduled_job_logs.html
@@ -108,7 +108,7 @@
     </thead>
     <tbody>
       {% for r in runs %}
-      <tr {% if r.status="" ="running" %}style="background-color: #fff3cd;" {% endif %}>
+      <tr {% if r.status == "running" %}style="background-color: #fff3cd;" {% endif %}>
         <td>{{ r.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
         <td>
           {% if r.status == 'success' %}<span class="status-success">✅ Erfolgreich</span> {% elif r.status == 'failed'

--- a/tests/test_stale_jobs.py
+++ b/tests/test_stale_jobs.py
@@ -1,0 +1,71 @@
+"""
+Test for cleaning up stale job runs on app startup.
+"""
+
+from flask import Flask
+
+from spo import create_app
+from spo.extensions import db
+from spo.models import ScheduledJob, ScheduledJobRun
+
+
+def test_stale_jobs_cleaned_on_startup(app: Flask):
+    """Test that running/queued jobs are marked as failed when app starts."""
+    with app.app_context():
+        # Create a test scheduled job
+        job = ScheduledJob(
+            job_name="Test Job",
+            job_type="test_job",
+            cron_expression="0 * * * *",
+            enabled=True,
+        )
+        db.session.add(job)
+        db.session.commit()
+
+        # Create job runs with different statuses
+        runs = [
+            ScheduledJobRun(scheduled_job_id=job.id, status="running", message="Was running"),
+            ScheduledJobRun(scheduled_job_id=job.id, status="queued", message="Was queued"),
+            ScheduledJobRun(
+                scheduled_job_id=job.id, status="success", message="Completed successfully"
+            ),
+            ScheduledJobRun(scheduled_job_id=job.id, status="failed", message="Already failed"),
+        ]
+        for run in runs:
+            db.session.add(run)
+        db.session.commit()
+
+        # Store the IDs
+        running_id = runs[0].id
+        queued_id = runs[1].id
+        success_id = runs[2].id
+        failed_id = runs[3].id
+
+        # Simulate app restart by creating a new app instance
+        # This will trigger the cleanup logic in create_app
+        new_app = create_app(start_jobs=False, run_seed=False)
+
+        with new_app.app_context():
+            # Check that running and queued jobs are now failed
+            running_run = ScheduledJobRun.query.get(running_id)
+            assert running_run.status == "failed"
+            assert "Container restarted" in running_run.message
+
+            queued_run = ScheduledJobRun.query.get(queued_id)
+            assert queued_run.status == "failed"
+            assert "Container restarted" in queued_run.message
+
+            # Check that success and failed jobs are unchanged
+            success_run = ScheduledJobRun.query.get(success_id)
+            assert success_run.status == "success"
+            assert success_run.message == "Completed successfully"
+
+            failed_run = ScheduledJobRun.query.get(failed_id)
+            assert failed_run.status == "failed"
+            assert failed_run.message == "Already failed"
+
+        # Cleanup
+        with app.app_context():
+            ScheduledJobRun.query.filter_by(scheduled_job_id=job.id).delete()
+            ScheduledJob.query.filter_by(id=job.id).delete()
+            db.session.commit()


### PR DESCRIPTION
- Fixed Jinja2 syntax error in admin_scheduled_job_logs.html line 111

- Added automatic cleanup of stale job runs on container startup

- Jobs with status running or queued are marked as failed when container restarts

- Added comprehensive test for stale job cleanup functionality